### PR TITLE
Avoid DTD entities expansion in SVGTileRenderer

### DIFF
--- a/src/main/java/org/mapfish/print/map/renderers/SVGTileRenderer.java
+++ b/src/main/java/org/mapfish/print/map/renderers/SVGTileRenderer.java
@@ -55,6 +55,9 @@ import org.xml.sax.InputSource;
 import com.lowagie.text.DocumentException;
 import com.lowagie.text.pdf.PdfContentByte;
 import com.lowagie.text.pdf.PdfGState;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.XMLConstants;
 
 public class SVGTileRenderer extends TileRenderer {
     public static final Logger LOGGER = Logger.getLogger(SVGTileRenderer.class);
@@ -166,7 +169,16 @@ public class SVGTileRenderer extends TileRenderer {
 
                 Document doc;
                 try {
-                    xslt.transform(new StreamSource(inputStream), transformedSvg);
+                    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+                    dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                    dbf.setValidating(false);
+                    dbf.setExpandEntityReferences(false);
+
+                    DocumentBuilder db = dbf.newDocumentBuilder();
+
+                    Document docParse = db.parse(inputStream);
+                    xslt.transform(new DOMSource(docParse), transformedSvg);
+
                     doc = (Document) transformedSvg.getNode();
 
                     if (LOGGER.isDebugEnabled()) {


### PR DESCRIPTION
To work properly requires to use `saxon`:

```
-Djavax.xml.transform.TransformerFactory=net.sf.saxon.TransformerFactoryImpl
```

`xalan` seem not supporting the settings to avoid the DTD entities.