### PR TITLE
MapPrinterServlet - fix string comparison

### DIFF
--- a/src/main/java/org/mapfish/print/servlet/MapPrinterServlet.java
+++ b/src/main/java/org/mapfish/print/servlet/MapPrinterServlet.java
@@ -147,7 +147,7 @@ public class MapPrinterServlet extends BaseMapServlet {
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
-        if (httpServletRequest.getMethod() == "POST") {
+        if (httpServletRequest.getMethod().equalsIgnoreCase("POST")) {
             try {
                 spec = getSpecFromPostBody(httpServletRequest);
             } catch (IOException e) {

--- a/src/main/java/org/mapfish/print/servlet/MapPrinterServlet.java
+++ b/src/main/java/org/mapfish/print/servlet/MapPrinterServlet.java
@@ -147,7 +147,7 @@ public class MapPrinterServlet extends BaseMapServlet {
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
-        if (httpServletRequest.getMethod().equalsIgnoreCase("POST")) {
+        if ("POST".equalsIgnoreCase(httpServletRequest.getMethod())) {
             try {
                 spec = getSpecFromPostBody(httpServletRequest);
             } catch (IOException e) {


### PR DESCRIPTION
The test should probably be a `.equals()` here

Anyway, testing different scenarios, I had some very weird results: where I was expecting the test to always evalute to false, I had a case where the condition resolved to true:

* under mfprintv2.2.0 bundled into GeoNetwork and using Jetty as a servlet container the case evaluated to false in my debugger, true when stepping over
* Doing the same with a tomcat9.x docker container and the condition evaluated to false.

There is probably some string interning black magick taking place over here, but at least we should reach the expected behaviour using equals instead of the "==" operator.
