### PR TITLE
[GEOT-7287] GeoTools API Change refactoring org.opengis to org.geotools.api

### DIFF
--- a/src/main/java/org/mapfish/print/Transformer.java
+++ b/src/main/java/org/mapfish/print/Transformer.java
@@ -19,12 +19,12 @@
 
 package org.mapfish.print;
 
-import org.geotools.geometry.DirectPosition2D;
+import org.geotools.geometry.Position2D;
 import org.geotools.referencing.CRS;
 import org.mapfish.print.config.Config;
 import org.geotools.referencing.GeodeticCalculator;
 import org.mapfish.print.utils.DistanceUnit;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 
 import com.lowagie.text.pdf.PdfContentByte;
 
@@ -160,7 +160,7 @@ public class Transformer implements Cloneable {
                 crs = CRS.decode(srsCode, !strictEpsg4326);
             }
             GeodeticCalculator calc = new GeodeticCalculator(crs);
-            DirectPosition2D directPosition2D = new DirectPosition2D(centerX,
+            Position2D directPosition2D = new Position2D(centerX,
                     centerY);
             directPosition2D.setCoordinateReferenceSystem(crs);
             calc.setStartingPosition(directPosition2D);

--- a/src/test/java/org/mapfish/print/config/layout/MapBlockTest.java
+++ b/src/test/java/org/mapfish/print/config/layout/MapBlockTest.java
@@ -25,7 +25,7 @@ import org.mapfish.print.utils.PJsonObject;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.pvalsecc.misc.FileUtilities;
 
 import java.io.File;


### PR DESCRIPTION
This changes covers GeoTools 30-SNAPSHOT API Change from ``org.opengis`` to ``org.geotools.api`` and resulting refactoring of the library.

This PR depends on https://github.com/geotools/geotools/pull/4367 and the availability of ``30-SNAPSHOT``.

See issue: https://github.com/mapfish/mapfish-print-v2/issues/13