### PR TITLE
Bump Xalan from 2.7.0 to 2.7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
       <dependency>
         <groupId>xalan</groupId>
         <artifactId>xalan</artifactId>
-        <version>2.7.0</version>
+        <version>2.7.3</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>


### PR DESCRIPTION
The Xalan project has fixed a few security issues and bugs since 2005 / 2.7.0; see https://xalan.apache.org/xalan-j/readme.html#done