### PR TITLE
Support building with Java 11 and Java 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,20 +12,18 @@ env:
 jobs:
   build:
     runs-on: [ubuntu-20.04]
+    strategy:
+      matrix:
+        java: [11, 17]
+    name: Java ${{ matrix.java }} build
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
-        java-version: 11
-    - name: Maven repository caching
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: mf-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          gt-maven-
+        java-version: ${{ matrix.java }}
+        cache: maven
     - name: Disable checksum offloading
       # See: https://github.com/actions/virtual-environments/issues/1187#issuecomment-686735760
       run: sudo ethtool -K eth0 tx off rx off

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    runs-on: [ubuntu-20.04]
+    runs-on: [ubuntu-22.04]
     strategy:
       matrix:
         java: [11, 17]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         java: [11, 17]
     name: Java ${{ matrix.java }} build
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v2
       with:

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,5 @@
+--add-opens java.base/java.lang=ALL-UNNAMED
+--add-opens java.base/java.util=ALL-UNNAMED
+--add-opens java.desktop/java.awt.image=ALL-UNNAMED
+--add-opens java.desktop/javax.imageio.stream=ALL-UNNAMED
+--add-opens java.desktop/javax.imageio=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,8 @@
     <pdfbox-version>2.0.33</pdfbox-version>
     <metrics-version>4.2.30</metrics-version>
     <jackson2.version>2.18.2</jackson2.version>
+    <fork.javac>true</fork.javac>
+    <javac.maxHeapSize>512m</javac.maxHeapSize>
   </properties>
   
   <dependencyManagement>
@@ -379,12 +381,31 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.11.0</version>
         <configuration>
-          <source>11</source>  <!-- The -source argument for the Java compiler. -->
-          <target>11</target>  <!-- The -target argument for the Java compiler. -->
+          <release>11</release> <!-- Java release version -->
           <debug>true</debug>   <!-- Whether to include debugging information.   -->
           <encoding>UTF-8</encoding> <!-- The -encoding argument for the Java compiler. -->
           <fork>${fork.javac}</fork> 
           <maxmem>${javac.maxHeapSize}</maxmem>
+        </configuration>
+      </plugin>
+      <!-- Surefire plugin for running tests -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.3</version>
+        <configuration>
+          <systemPropertyVariables>
+            <java.awt.headless>true</java.awt.headless>
+          </systemPropertyVariables>
+          <!-- These argLine options are needed for the forked test JVM,
+               .mvn/jvm.config only applies to the main Maven process -->
+          <argLine>
+            --add-opens java.base/java.lang=ALL-UNNAMED
+            --add-opens java.base/java.util=ALL-UNNAMED
+            --add-opens java.desktop/java.awt.image=ALL-UNNAMED
+            --add-opens java.desktop/javax.imageio.stream=ALL-UNNAMED
+            --add-opens java.desktop/javax.imageio=ALL-UNNAMED
+          </argLine>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Update the project to build and test with Java 11 and Java 17.

- Enhanced GitHub Actions workflow (`build.yml`) to use a build matrix for Java 11 and 17, and updated JDK setup and Maven caching.
- Updated `pom.xml`:
  - Configured `maven-compiler-plugin` with `<release>11</release>`.
  - Added and configured `maven-surefire-plugin` with necessary `--add-opens` arguments for test execution on newer JDKs.
- Introduced `.mvn/jvm.config` with `--add-opens` arguments to allow reflective access for the Maven build process on newer JDKs.