### PR TITLE
Start 2.4.x release with Imagen 0.4.0 update and GeoTools 34-SNAPSHOT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: [ubuntu-22.04]
     strategy:
       matrix:
-        java: [11, 17]
+        java: [17,21]
     name: Java ${{ matrix.java }} build
     steps:
     - uses: actions/checkout@v4

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <log4j-version>2.24.3</log4j-version>
     <spring-version>5.3.39</spring-version>
-    <gt-version>31.6</gt-version>
-    <imagen.version>0.4-SNAPSHOT</imagen.version>
+    <gt-version>34-SNAPSHOT</gt-version>
+    <imagen.version>0.4.0</imagen.version>
     <pdfbox-version>2.0.34</pdfbox-version>
     <metrics-version>4.2.30</metrics-version>
     <jackson2.version>2.18.2</jackson2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   
   <groupId>org.mapfish.print</groupId>
   <artifactId>print-lib</artifactId>
-  <version>2.3-SNAPSHOT</version>
+  <version>2.4-SNAPSHOT</version>
 
   <description>
     MapFish Print Version 2 has reached end-of-life and is no longer under active development.

--- a/src/main/java/org/mapfish/print/config/layout/Layout.java
+++ b/src/main/java/org/mapfish/print/config/layout/Layout.java
@@ -114,21 +114,23 @@ public class Layout {
     }
 
     /**
-     * Taken for compatibility, please use extraPages.
+     * Retained for compatibility, please use extraPages.
      * 
-     * @deprecated
+     * @deprecated Please use extraPages.
      * @return
      */
+    @Deprecated
     public DynamicImagesPage getDynamicImagesPage() {
         return dynamicImagesPage;
     }
 
     /**
-     * Taken for compatibility, please use extraPages.
+     * Retained for compatibility, please use extraPages.
      * 
-     * @deprecated
+     * @deprecated Please use extraPages.
      * @return
      */
+    @Deprecated
     public void setDynamicImagesPage(DynamicImagesPage dynamicImagesPage) {
         this.dynamicImagesPage = dynamicImagesPage;
     }

--- a/src/main/java/org/mapfish/print/output/FileCachingJaiMosaicOutputFactory.java
+++ b/src/main/java/org/mapfish/print/output/FileCachingJaiMosaicOutputFactory.java
@@ -20,19 +20,19 @@
 package org.mapfish.print.output;
 
 import com.lowagie.text.DocumentException;
-import com.sun.media.jai.codec.FileSeekableStream;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.rendering.ImageType;
 import org.apache.pdfbox.rendering.PDFRenderer;
+import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.RenderedOp;
+import org.eclipse.imagen.media.codec.FileSeekableStream;
 import org.mapfish.print.RenderingContext;
 import org.mapfish.print.utils.PJsonObject;
 
 import javax.imageio.ImageIO;
-import javax.media.jai.JAI;
-import javax.media.jai.RenderedOp;
 import java.awt.image.BufferedImage;
 import java.awt.image.RenderedImage;
 import java.awt.image.renderable.ParameterBlock;

--- a/src/main/java/org/mapfish/print/output/InMemoryJaiMosaicOutputFactory.java
+++ b/src/main/java/org/mapfish/print/output/InMemoryJaiMosaicOutputFactory.java
@@ -26,14 +26,14 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.rendering.ImageType;
 import org.apache.pdfbox.rendering.PDFRenderer;
+import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.RenderedOp;
+import org.eclipse.imagen.TileCache;
+import org.eclipse.imagen.media.mosaic.MosaicDescriptor;
 import org.mapfish.print.RenderingContext;
 import org.mapfish.print.utils.PJsonObject;
 
 import javax.imageio.ImageIO;
-import javax.media.jai.JAI;
-import javax.media.jai.RenderedOp;
-import javax.media.jai.TileCache;
-import javax.media.jai.operator.MosaicDescriptor;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.awt.image.RenderedImage;

--- a/src/main/java/org/mapfish/print/utils/PJsonArray.java
+++ b/src/main/java/org/mapfish/print/utils/PJsonArray.java
@@ -92,6 +92,7 @@ public class PJsonArray extends PJsonElement {
     /**
      * @deprecated Use only if you know what you are doing!
      */
+    @Deprecated
     public JSONArray getInternalArray() {
         return array;
     }

--- a/src/test/java/apps/ListJAIOperations.java
+++ b/src/test/java/apps/ListJAIOperations.java
@@ -19,9 +19,10 @@
 
 package apps;
 
-import javax.media.jai.JAI;
-import javax.media.jai.OperationRegistry;
-import javax.media.jai.RegistryMode;
+
+import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.OperationRegistry;
+import org.eclipse.imagen.RegistryMode;
 
 public class ListJAIOperations {
   public ListJAIOperations() {

--- a/src/test/java/apps/MosiacImages.java
+++ b/src/test/java/apps/MosiacImages.java
@@ -26,10 +26,10 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 
 import javax.imageio.ImageIO;
-import javax.media.jai.ImageLayout;
-import javax.media.jai.JAI;
-import javax.media.jai.PlanarImage;
-import javax.media.jai.RenderedOp;
+import org.eclipse.imagen.ImageLayout;
+import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.PlanarImage;
+import org.eclipse.imagen.RenderedOp;
 
 /**
  * User: jeichar


### PR DESCRIPTION
This PR updates imports from javax.media.jai.JAI to org.eclipse.imagen.JAI

This change sets base as Java 17 minimum and is backwards incompatible making for 2.4-SNAPSHOT ahead of 2.4.0 release.