### PR TITLE
Bumped xalan to 2.7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
       <dependency>
         <groupId>xalan</groupId>
         <artifactId>xalan</artifactId>
-        <version>2.7.0</version>
+        <version>2.7.3</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,11 @@
         <version>2.7.3</version>
       </dependency>
       <dependency>
+        <groupId>xalan</groupId>
+        <artifactId>serializer</artifactId>
+        <version>2.7.3</version>
+      </dependency>
+      <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-core</artifactId>
         <version>${metrics-version}</version>
@@ -276,6 +281,11 @@
     <dependency>
       <groupId>xalan</groupId>
       <artifactId>xalan</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>xalan</groupId>
+      <artifactId>serializer</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
These changes stem from a failing xalan bump to v 2.7.3, aiming to fix the upgrade.