### PR TITLE
[2.3.x] Upgrade pdfbox to version 3.0.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <log4j-version>2.24.3</log4j-version>
     <spring-version>5.3.39</spring-version>
     <gt-version>31.6</gt-version>
-    <pdfbox-version>2.0.34</pdfbox-version>
+    <pdfbox-version>3.0.3</pdfbox-version>
     <metrics-version>4.2.30</metrics-version>
     <jackson2.version>2.18.2</jackson2.version>
     <fork.javac>true</fork.javac>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <log4j-version>2.24.3</log4j-version>
     <spring-version>5.3.39</spring-version>
     <gt-version>31.6</gt-version>
-    <pdfbox-version>3.0.3</pdfbox-version>
+    <pdfbox-version>3.0.8</pdfbox-version>
     <metrics-version>4.2.30</metrics-version>
     <jackson2.version>2.18.2</jackson2.version>
     <fork.javac>true</fork.javac>

--- a/src/main/java/org/mapfish/print/output/FileCachingJaiMosaicOutputFactory.java
+++ b/src/main/java/org/mapfish/print/output/FileCachingJaiMosaicOutputFactory.java
@@ -23,6 +23,7 @@ import com.lowagie.text.DocumentException;
 import com.sun.media.jai.codec.FileSeekableStream;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.rendering.ImageType;
@@ -140,8 +141,7 @@ public class FileCachingJaiMosaicOutputFactory extends InMemoryJaiMosaicOutputFa
 
         private List<ImageInfo> createImages(PJsonObject jsonSpec, File tmpFile, RenderingContext context) throws IOException {
             List<ImageInfo> images = new ArrayList<ImageInfo>();
-            PDDocument pdf = PDDocument.load(tmpFile);
-            try {
+            try (PDDocument pdf = Loader.loadPDF(tmpFile)) {
                 PDFRenderer pdfRenderer = new PDFRenderer(pdf);
                 for (PDPage page : pdf.getPages())
                 {
@@ -150,8 +150,6 @@ public class FileCachingJaiMosaicOutputFactory extends InMemoryJaiMosaicOutputFa
                     ImageIO.write(img, "TIFF", file);
                     images.add(new ImageInfo(file, img.getWidth(), img.getHeight()));
                 }
-            } finally {
-                pdf.close();
             }
             return images;
         }

--- a/src/main/java/org/mapfish/print/output/InMemoryJaiMosaicOutputFactory.java
+++ b/src/main/java/org/mapfish/print/output/InMemoryJaiMosaicOutputFactory.java
@@ -22,6 +22,7 @@ package org.mapfish.print.output;
 import com.lowagie.text.DocumentException;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.rendering.ImageType;
@@ -153,8 +154,7 @@ public class InMemoryJaiMosaicOutputFactory implements OutputFormatFactory {
 
         private List<BufferedImage> createImages(PJsonObject jsonSpec, File tmpFile, RenderingContext context) throws IOException {
             List<BufferedImage> images = new ArrayList<BufferedImage>();
-            PDDocument pdf = PDDocument.load(tmpFile);
-            try {
+            try (PDDocument pdf = Loader.loadPDF(tmpFile)) {
                 @SuppressWarnings("unchecked")
                 PDFRenderer pdfRenderer = new PDFRenderer(pdf);
                 for (PDPage page : pdf.getPages())
@@ -162,8 +162,6 @@ public class InMemoryJaiMosaicOutputFactory implements OutputFormatFactory {
                     BufferedImage img = pdfRenderer.renderImageWithDPI(images.size(), calculateDPI(context, jsonSpec), ImageType.ARGB);
                     images.add(img);
                 }
-            } finally {
-                pdf.close();
             }
             return images;
         }

--- a/src/test/java/apps/Main.java
+++ b/src/test/java/apps/Main.java
@@ -19,6 +19,7 @@
 
 package apps;
 
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.rendering.ImageType;
 import org.apache.pdfbox.rendering.PDFRenderer;
@@ -39,31 +40,17 @@ public class Main {
 
 
     public static void main(final String[] args) throws IOException {
-        PDDocument document = null;
-            try
-            {
-                document = PDDocument.load( new File("/tmp/print-out.pdf"));
+        try (PDDocument document = Loader.loadPDF(new File("/tmp/print-out.pdf"))) {
+            ImageType imageType = ImageType.ARGB;
 
-                ImageType imageType = ImageType.ARGB;
-
-                PDFRenderer pdfRenderer = new PDFRenderer(document);
-                int pageCounter = 0;
-                while (pageCounter < 3)
-                {
-                    BufferedImage bim = pdfRenderer.renderImageWithDPI(pageCounter, 56, imageType);
-                    ImageIOUtil.writeImage(bim, "/tmp/img--" + (pageCounter++) + ".png", 56);
-                }
+            PDFRenderer pdfRenderer = new PDFRenderer(document);
+            int pageCounter = 0;
+            while (pageCounter < 3) {
+                BufferedImage bim = pdfRenderer.renderImageWithDPI(pageCounter, 56, imageType);
+                ImageIOUtil.writeImage(bim, "/tmp/img--" + (pageCounter++) + ".png", 56);
             }
-            catch (Exception e)
-            {
-                System.err.println(e);
-            }
-            finally
-            {
-                if( document != null )
-                {
-                    document.close();
-                }
-            }
+        } catch (Exception e) {
+            System.err.println(e);
         }
+    }
 }


### PR DESCRIPTION
Projects like GeoNetwork that use MapFish, recently upgraded to use pdfbox 3.0.3, due to an upgrade of Apache FOP (see https://github.com/geonetwork/core-geonetwork/pull/9456).

MapFish requires pdfbox 2.0.34, which has some API changes causing errors when using MapFish with pdfbox 3.0.3:

```
Caused by: java.lang.NoSuchMethodError: 'org.apache.pdfbox.pdmodel.PDDocument org.apache.pdfbox.pdmodel.PDDocument.load(java.io.File)'
    at org.mapfish.print.output.FileCachingJaiMosaicOutputFactory$ImageOutputScalable.createImages(FileCachingJaiMosaicOutputFactory.java:143)
    at org.mapfish.print.output.FileCachingJaiMosaicOutputFactory$ImageOutputScalable.print(FileCachingJaiMosaicOutputFactory.java:89)
...
```

This change requests updates MapFish to use pdfbox 3.0.3