### PR TITLE
Update to ImageN 0.9.3-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <!--log4j-version>2.24.3</log4j-version-->
     <spring.version>7.0.8</spring.version>
     <gt.version>35.0</gt.version>
-    <imagen.version>0.9.2</imagen.version> <!-- sync with gt-platform-dependences -->
+    <imagen.version>0.9.3-SNAPSHOT</imagen.version> <!-- sync with gt-platform-dependences -->
     <pdfbox.version>3.0.8</pdfbox.version>
     <metrics-version>4.2.39</metrics-version>
     <!--jackson2.version>2.18.2</jackson2.version-->


### PR DESCRIPTION
Check mapfish-print-v2 works with ImageN 0.9.3 (change to prefix jars for operations).

* https://github.com/geotools/geotools/pull/5823
* https://github.com/geotools/geotools/pull/5824