### PR TITLE
Update com.github.librepdf:openpdf to 2.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ GeoCat BV has maintained this series as needed to support geoserver and core-geo
 
 | Release | Java | Notes |
 | ------- | ---- | ----- |
-| 2.5.x   | 17   | Migrate to JarkartaEE, for SpringFramework 7 compatibility |
+| 2.5.x   | 17   | Migrate to JakartaEE, for SpringFramework 7 compatibility |
 | 2.4.x   | 17   | Migrate to ImageN, for Java 17 compatibility |
 | 2.3.x   | 11   | Migrate to Log4j2, combine with geosolutions-it/mapfish-print fork |
 | 2.2.x   | 8    | Migrate to OpenPDF due to license conflicts |

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
       <dependency>
         <groupId>com.github.librepdf</groupId>
         <artifactId>openpdf</artifactId>
-        <version>1.4.2</version>
+        <version>2.0.5</version>
       </dependency>
       <dependency>
         <groupId>org.json</groupId>


### PR DESCRIPTION
This is the latest version that supports Java 17 and will match the (proposed) version for GeoServer, see https://github.com/geoserver/geoserver/pull/9631